### PR TITLE
Enhance the `new` command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,6 +66,13 @@ impl Cli {
         // Generate ID: use custom ID if provided, otherwise use current date
         let id = custom_id.unwrap_or_else(|| format!("{}", Local::now().format("%Y%m%d")));
 
+        // Check if entry already exists to prevent data loss
+        if Entry::load(&id, storage)?.is_some() {
+            eprintln!("Entry with ID '{}' already exists.", id);
+            eprintln!("To edit the existing entry, use: devlog edit --id {}", id);
+            process::exit(1);
+        }
+
         let content = match message {
             Some(msg) => msg,
             None => Self::open_editor_for_content(None)?,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::entry::Entry;
 use crate::storage::EntryStorage;
+use chrono::{Local, NaiveDate};
 use clap::{Parser, Subcommand};
 use std::process;
 
@@ -20,10 +21,14 @@ pub enum Commands {
         /// Inline message for the entry
         #[arg(short, long)]
         message: Option<String>,
+        /// Optional ID for the entry (format: YYYMMDD)
+        #[arg(long, value_name = "YYYYMMDD")]
+        id: Option<String>,
     },
     /// Edit an existing entry
     Edit {
         /// Entry ID to edit (format: YYYYMMDD)
+        #[arg(long, value_name = "YYYYMMDD")]
         id: String,
     },
 }
@@ -37,8 +42,8 @@ impl Cli {
         let storage = EntryStorage::new(None)?;
 
         match cli.command {
-            Commands::New { message } => {
-                Self::handle_new_command(message, &storage)?;
+            Commands::New { message, id } => {
+                Self::handle_new_command(message, id, &storage)?;
             }
             Commands::Edit { id } => {
                 Self::handle_edit_command(id, &storage)?;
@@ -51,8 +56,16 @@ impl Cli {
     /// Handle the new subcommand
     fn handle_new_command(
         message: Option<String>,
+        custom_id: Option<String>,
         storage: &EntryStorage,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        // Validate custom ID format if provided
+        if let Some(ref id) = custom_id {
+            Self::validate_id_format(id)?;
+        }
+        // Generate ID: use custom ID if provided, otherwise use current date
+        let id = custom_id.unwrap_or_else(|| format!("{}", Local::now().format("%Y%m%d")));
+
         let content = match message {
             Some(msg) => msg,
             None => Self::open_editor_for_content(None)?,
@@ -63,8 +76,8 @@ impl Cli {
             process::exit(1);
         }
 
-        // Create new entry
-        let entry = Entry::new(content);
+        // Create new entry with mandatory ID
+        let entry = Entry::new(content, id);
 
         // Save the entry
         entry.save(storage)?;
@@ -106,6 +119,13 @@ impl Cli {
 
         println!("Updated entry: {}", id);
 
+        Ok(())
+    }
+
+    /// Validate that the ID is in YYYYMMDD format
+    fn validate_id_format(id: &str) -> Result<(), Box<dyn std::error::Error>> {
+        NaiveDate::parse_from_str(id, "%Y%m%d")
+            .map(|_| format!("Invalid date format '{}'. Expected YYYYMMDD formate", id))?;
         Ok(())
     }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -38,11 +38,8 @@ pub struct Entry {
 }
 
 impl Entry {
-    /// Create a new entry with inital content
-    pub fn new(content: String) -> Self {
-        let now = Local::now();
-        let id = format!("{}", now.format("%Y%m%d"));
-
+    /// Create a new entry with initial content and ID
+    pub fn new(content: String, id: String) -> Self {
         // Start with empty entry and apply events
         let mut entry = Entry {
             events: Vec::new(),
@@ -53,7 +50,7 @@ impl Entry {
         let event = EntryEvent::Created {
             id,
             content,
-            timestamp: now,
+            timestamp: Local::now(),
         };
         entry.apply_event(event);
         entry.parse_annotations(); // Automatically parse annotations on creation
@@ -208,11 +205,11 @@ mod tests {
 
     #[test]
     fn test_new_entry_basic() {
-        let entry = Entry::new("Test content".to_string());
+        let entry = Entry::new("Test content".to_string(), "20250905".to_string());
         let state = entry.current_state();
 
         assert_eq!(state.content, "Test content");
-        assert!(!state.id.is_empty());
+        assert_eq!(state.id, "20250905");
 
         // Should have 2 events: Created and AnnotationParsed
         assert_eq!(entry.events.len(), 2);
@@ -220,7 +217,10 @@ mod tests {
 
     #[test]
     fn test_new_entry_with_annotations() {
-        let entry = Entry::new("Worked with @alice on ::search_engine using +rust".to_string());
+        let entry = Entry::new(
+            "Worked with @alice on ::search_engine using +rust".to_string(),
+            "20250905".to_string(),
+        );
         let state = entry.current_state();
 
         assert_eq!(
@@ -240,7 +240,10 @@ mod tests {
 
     #[test]
     fn test_new_entry_preserves_annotation_order() {
-        let entry = Entry::new("Met @alice then @bob then @alice again".to_string());
+        let entry = Entry::new(
+            "Met @alice then @bob then @alice again".to_string(),
+            "20250905".to_string(),
+        );
         let state = entry.current_state();
 
         // Vec preserves order and allows duplicates
@@ -252,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_update_content() {
-        let mut entry = Entry::new("Initial content".to_string());
+        let mut entry = Entry::new("Initial content".to_string(), "20250905".to_string());
         let initial_events = entry.events().len();
 
         entry.update_content("Updated with @bob and +learning".to_string());
@@ -268,7 +271,7 @@ mod tests {
 
     #[test]
     fn test_multiple_content_updates() {
-        let mut entry = Entry::new("Initial".to_string());
+        let mut entry = Entry::new("Initial".to_string(), "20250905".to_string());
 
         entry.update_content("First update @alice".to_string());
         entry.update_content("Second update @bob +rust".to_string());
@@ -371,7 +374,10 @@ mod tests {
     #[test]
     fn test_new_and_from_events_consistency() {
         // Create entry using new()
-        let entry1 = Entry::new("Test content @alice +rust".to_string());
+        let entry1 = Entry::new(
+            "Test content @alice +rust".to_string(),
+            "20250905".to_string(),
+        );
 
         // Create entry using from_events() with same events
         let events = entry1.events().to_vec();
@@ -388,11 +394,11 @@ mod tests {
 
     #[test]
     fn test_to_markdown_basic() {
-        let entry = Entry::new("Simple content".to_string());
+        let entry = Entry::new("Simple content".to_string(), "20250905".to_string());
         let markdown = entry.to_markdown();
 
         assert!(markdown.contains("---"));
-        assert!(markdown.contains("id:"));
+        assert!(markdown.contains("id: 20250905"));
         assert!(markdown.contains("created_at:"));
         assert!(markdown.contains("updated_at:"));
         assert!(markdown.contains("tags: []"));
@@ -403,7 +409,10 @@ mod tests {
 
     #[test]
     fn test_to_markdown_with_annotations() {
-        let entry = Entry::new("Worked with @alice and @bob on ::project using +rust".to_string());
+        let entry = Entry::new(
+            "Worked with @alice and @bob on ::project using +rust".to_string(),
+            "20250905".to_string(),
+        );
         let markdown = entry.to_markdown();
 
         assert!(markdown.contains("---"));
@@ -418,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_to_markdown_empty_annotations() {
-        let entry = Entry::new("No annotations here".to_string());
+        let entry = Entry::new("No annotations here".to_string(), "20250905".to_string());
         let markdown = entry.to_markdown();
 
         assert!(markdown.contains("tags: []"));
@@ -430,6 +439,7 @@ mod tests {
     fn test_to_markdown_multiple_annotations() {
         let entry = Entry::new(
             "Complex: @alice @bob @charlie +rust +tokio +async ::project1 ::project2".to_string(),
+            "20250905".to_string(),
         );
         let markdown = entry.to_markdown();
 
@@ -446,7 +456,10 @@ mod tests {
         let storage = EntryStorage::new(Some(temp_dir.path().to_path_buf())).unwrap();
 
         // Simulate 'devlog new' command
-        let entry = Entry::new("Initial content @alice +rust".to_string());
+        let entry = Entry::new(
+            "Initial content @alice +rust".to_string(),
+            "20250905".to_string(),
+        );
         entry.save(&storage).unwrap();
 
         // Verify initial events are saved


### PR DESCRIPTION
Updates:
1. add the `--id` option to the `new` command, so that users can backfill their journals. validation of `id` is also implemented.
2. when users run the `new` command, check if the entry id already exists, if yes, remind the users to use the `edit` command instead. Without this function, the new entry will overwrite the existing one.